### PR TITLE
Fix the bottom padding of the employee list header on the landscape mode

### DIFF
--- a/EmployeeHub/EmployeeHub/Modules/Employees/EmployeeList/EmployeeListView.swift
+++ b/EmployeeHub/EmployeeHub/Modules/Employees/EmployeeList/EmployeeListView.swift
@@ -27,7 +27,7 @@ struct EmployeeListView: View {
                         .frame(height: 188)
                         .cornerRadius(12)
                         .ignoresSafeArea(.all)
-                        .padding(.bottom, -60)
+                        .padding(.bottom, -30)
                     
                     EmployeeList(viewModel: viewModel)
                 }


### PR DESCRIPTION
### Summary

This pull request introduces a minor yet impactful adjustment to the bottom padding of the custom header view within the employee list. The primary goal is to enhance the app's visual appearance and usability when viewed in landscape orientation.

### Changes

- Modified the bottom padding value of the custom header view in the employee list to ensure it aligns properly and looks visually appealing in landscape mode.

### Testing

The changes have been tested on various devices and simulators to ensure that the new bottom padding behaves as expected in different scenarios, including:
- Switching between portrait and landscape orientations.
- Ensuring no impact on the header's appearance and functionality in portrait mode.
- Verifying that the adjustment does not affect other UI elements or the overall layout of the employee list.